### PR TITLE
Made some changes to the build environment files.

### DIFF
--- a/ChatterThemepack/ThemePack.csproj
+++ b/ChatterThemepack/ThemePack.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\..\..\Program Files\VoiceAttack\Apps\VAICOMPRO\</OutputPath>
+    <OutputPath>..\bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -27,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\..\..\Program Files\VoiceAttack\Apps\VAICOMPRO\</OutputPath>
+    <OutputPath>..\bin\Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/RIO/RIO.csproj
+++ b/RIO/RIO.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\..\..\Program Files\VoiceAttack\Apps\VAICOMPRO\</OutputPath>
+    <OutputPath>..\bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -27,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\..\..\Program Files\VoiceAttack\Apps\VAICOMPRO\</OutputPath>
+    <OutputPath>..\bin\Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/VAICOM/FodyWeavers.xml
+++ b/VAICOM/FodyWeavers.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <Weavers>
-  
+  <Costura />
 </Weavers>

--- a/VAICOM/VAICOM.csproj
+++ b/VAICOM/VAICOM.csproj
@@ -19,21 +19,22 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\..\..\Program Files\VoiceAttack\Apps\VAICOMPRO\</OutputPath>
+    <OutputPath>..\bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>2</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\..\..\Program Files\VoiceAttack\Apps\VAICOMPRO\</OutputPath>
+    <OutputPath>..\bin\Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <WarningLevel>2</WarningLevel>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>
@@ -61,6 +62,10 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Costura, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Costura.Fody.1.6.0\lib\dotnet\Costura.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
@@ -74,7 +79,6 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="NVorbis, Version=0.8.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NVorbis.0.8.6\lib\net35\NVorbis.dll</HintPath>
@@ -368,6 +372,7 @@
     <Resource Include="Resources\Images\YouTubePlay.png" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Fonts\MS33558.ttf" />
     <EmbeddedResource Include="Resources\Files\base-menu-window" />
     <EmbeddedResource Include="Resources\Files\Debug_chunk.lua" />
@@ -517,8 +522,16 @@ TASKKILL /FI "STATUS eq RUNNING" /F /IM XDesProc.exe</PreBuildEvent>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Fody.2.0.0\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.0.0\build\dotnet\Fody.targets'))" />
     <Error Condition="!Exists('..\packages\Fody.2.0.0\build\netstandard1.4\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.0.0\build\netstandard1.4\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Costura.Fody.1.6.0\build\dotnet\Costura.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.1.6.0\build\dotnet\Costura.Fody.targets'))" />
   </Target>
   <Import Project="..\packages\Fody.2.0.0\build\netstandard1.4\Fody.targets" Condition="Exists('..\packages\Fody.2.0.0\build\netstandard1.4\Fody.targets')" />
+  <Import Project="..\packages\Costura.Fody.1.6.0\build\dotnet\Costura.Fody.targets" Condition="Exists('..\packages\Costura.Fody.1.6.0\build\dotnet\Costura.Fody.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>cd "$(TargetDir)"
+del *.pdb
+del *.config
+</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/VAICOM/app.config
+++ b/VAICOM/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/VAICOM/packages.config
+++ b/VAICOM/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Costura.Fody" version="1.6.0" targetFramework="net472" developmentDependency="true" />
   <package id="Fody" version="2.0.0" targetFramework="net472" developmentDependency="true" />
-  <package id="NAudio" version="1.8.5" targetFramework="net472" />
-  <package id="NAudio.Vorbis" version="1.0.0.0" targetFramework="net472" />
+  <package id="NAudio" version="1.8.5" targetFramework="net452" />
+  <package id="NAudio.Vorbis" version="1.0.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
-  <package id="NVorbis" version="0.8.6" targetFramework="net472" />
+  <package id="NVorbis" version="0.8.6" targetFramework="net452" />
   <package id="SharpDX" version="4.2.0" targetFramework="net472" />
 </packages>

--- a/VAICOM28.sln
+++ b/VAICOM28.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30128.74
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32929.385
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VAICOM", "VAICOM\VAICOM.csproj", "{AF6CE74F-FE22-4BB4-81CC-53363A59E703}"
 EndProject
@@ -42,6 +42,7 @@ Global
 		{AF6CE74F-FE22-4BB4-81CC-53363A59E703}.Release|x64.ActiveCfg = Release|x64
 		{AF6CE74F-FE22-4BB4-81CC-53363A59E703}.Release|x64.Build.0 = Release|x64
 		{98D43BAE-1089-47EB-A7CF-70E2A1787A9B}.Debug|Any CPU.ActiveCfg = Release|Any CPU
+		{98D43BAE-1089-47EB-A7CF-70E2A1787A9B}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{98D43BAE-1089-47EB-A7CF-70E2A1787A9B}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{98D43BAE-1089-47EB-A7CF-70E2A1787A9B}.Debug|x64.Build.0 = Debug|Any CPU
 		{98D43BAE-1089-47EB-A7CF-70E2A1787A9B}.Release 3.5 Client|Any CPU.ActiveCfg = Release|Any CPU
@@ -57,6 +58,7 @@ Global
 		{98D43BAE-1089-47EB-A7CF-70E2A1787A9B}.Release|x64.ActiveCfg = Release|x64
 		{98D43BAE-1089-47EB-A7CF-70E2A1787A9B}.Release|x64.Build.0 = Release|x64
 		{EFA2BADB-FF9E-4ACB-B272-BD4B7CC13199}.Debug|Any CPU.ActiveCfg = Release|Any CPU
+		{EFA2BADB-FF9E-4ACB-B272-BD4B7CC13199}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{EFA2BADB-FF9E-4ACB-B272-BD4B7CC13199}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{EFA2BADB-FF9E-4ACB-B272-BD4B7CC13199}.Debug|x64.Build.0 = Debug|Any CPU
 		{EFA2BADB-FF9E-4ACB-B272-BD4B7CC13199}.Release 3.5 Client|Any CPU.ActiveCfg = Release|Any CPU
@@ -72,6 +74,7 @@ Global
 		{EFA2BADB-FF9E-4ACB-B272-BD4B7CC13199}.Release|x64.ActiveCfg = Release|x64
 		{EFA2BADB-FF9E-4ACB-B272-BD4B7CC13199}.Release|x64.Build.0 = Release|x64
 		{1F03A050-0B98-4A25-A090-92355445CA48}.Debug|Any CPU.ActiveCfg = Release|Any CPU
+		{1F03A050-0B98-4A25-A090-92355445CA48}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{1F03A050-0B98-4A25-A090-92355445CA48}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{1F03A050-0B98-4A25-A090-92355445CA48}.Debug|x64.Build.0 = Debug|Any CPU
 		{1F03A050-0B98-4A25-A090-92355445CA48}.Release 3.5 Client|Any CPU.ActiveCfg = Release|Any CPU

--- a/VAICOM_Installer/VAICOM_Installer.vdproj
+++ b/VAICOM_Installer/VAICOM_Installer.vdproj
@@ -119,7 +119,7 @@
         "DisplayName" = "8:Release"
         "IsDebugOnly" = "11:FALSE"
         "IsReleaseOnly" = "11:TRUE"
-        "OutputFilename" = "8:..\\..\\..\\..\\..\\Program Files\\VoiceAttack\\Apps\\VAICOMPRO\\VAICOM PRO for DCS World.msi"
+        "OutputFilename" = "8:..\\bin\\Release\\VAICOM PRO for DCS World.msi"
         "PackageFilesAs" = "3:2"
         "PackageFileSize" = "3:-2147483648"
         "CabType" = "3:1"

--- a/VA_watchdog/VAICOM_App.csproj
+++ b/VA_watchdog/VAICOM_App.csproj
@@ -21,7 +21,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\..\..\Program Files\VoiceAttack\Apps\VAICOMPRO\</OutputPath>
+    <OutputPath>..\bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -30,7 +30,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\..\..\Program Files\VoiceAttack\Apps\VAICOMPRO\</OutputPath>
+    <OutputPath>..\bin\Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION

- Added Fody to build all resource dlls into a single dll for a cleaner system. 

- Needed to add post build actions for fody and symbols cleanup. The final VAICOM.dll should be able to be shrunk down but I haven't looked into it yet. 

- Changed output paths so they weren't quite so obnoxious. Basic housekeeping.