### PR TITLE
Prefer to use English Text to Speech Engine fixes #29

### DIFF
--- a/VAICOM/Extensions/AOCS/AOCS.cs
+++ b/VAICOM/Extensions/AOCS/AOCS.cs
@@ -18,6 +18,7 @@ using System.Speech.AudioFormat;
 using VAICOM.Extensions.WorldAudio;
 using System.Windows.Forms;
 using VAICOM.Extensions.Kneeboard;
+using System.Globalization;
 
 namespace VAICOM
 {
@@ -86,7 +87,7 @@ namespace VAICOM
                         var mi = State.synth.GetType().GetMethod("SetOutputStream", BindingFlags.Instance | BindingFlags.NonPublic);               
                         mi.Invoke(State.synth, new object[] { wavstream, outformat, true, true });
 
-                        PromptBuilder builder = new PromptBuilder();
+                        PromptBuilder builder = new PromptBuilder(CultureInfo.GetCultureInfo("en-US"));
                         builder.AppendText(str);
                         State.synth.Speak(builder);
                         wavstream.Seek(0, SeekOrigin.Begin);


### PR DESCRIPTION
This should fix the main issue in #29  without adding a "Select Language/Voice" functionality by always preferring an English voice.
(Tried on a Win11 Pro German installation)