### PR TITLE
Fix TX Link PTT Needing 2 Clicks after successfull Command Recognition

### DIFF
--- a/VAICOM/PushToTalk/PTTHandler.cs
+++ b/VAICOM/PushToTalk/PTTHandler.cs
@@ -174,7 +174,7 @@ namespace VAICOM
                 {
                     State.transmitting = false;
                     PTTkey.relay = false;
-
+                    TXLinkToggle = false;
                     if (keypress)
                     {
                         DcsClient.SendUpdateRequest();


### PR DESCRIPTION
properly resets ptt state so that it doesnt think its active and tries to disable it on the first ptt click, which caused the neeed to click ptt twice before it recognized new commands