### PR TITLE
Remove the replacement of the Kola ATC radio frequencies

### DIFF
--- a/VAICOM/FileManager/LuaFiles.cs
+++ b/VAICOM/FileManager/LuaFiles.cs
@@ -576,30 +576,32 @@ namespace VAICOM
                   kneeboard = false,
                 } },
 
-                {"2.8 Kola_radio.lua",new Server.LuaFile
-                {
-                  filename = "radio.lua",
-                  installfolder = "Mods\\terrains\\Kola",
-                  installfolder_legacy = "Mods\\terrains\\Kola",
-                  append = false, // <--- Do Not append must replace,
-                  root = true,
-                  hardreset = true,
-                  orig = Properties.Resources.Orig_Terrain_Kola_radio,
-                  source = Properties.Resources.Append_Terrain_Kola_radio,
-                  stringreplace = false,
-                  stringorig = Properties.Resources.Orig_Terrain_Kola_radio,
-                  stringsource = Properties.Resources.Append_Terrain_Kola_radio,
-                  version ="2.8",
-                  canremove = true,
-                  reset = false,
-                  //ACTIVE:
-                  install = true,
-                  export = false,
-                  autoremove  = true,
-                  quiet  = false,
-                  AIRIO = true,
-                  kneeboard = false,
-                } },
+                // Currently unused.
+                // Template to be used for future releases of terrains needing radio.lua replacement.
+                // {"2.8 Kola_radio.lua",new Server.LuaFile
+                // {
+                //   filename = "radio.lua",
+                //   installfolder = "Mods\\terrains\\Kola",
+                //   installfolder_legacy = "Mods\\terrains\\Kola",
+                //   append = false, // <--- Do Not append must replace,
+                //   root = true,
+                //   hardreset = true,
+                //   orig = Properties.Resources.Orig_Terrain_Kola_radio,
+                //   source = Properties.Resources.Append_Terrain_Kola_radio,
+                //   stringreplace = false,
+                //   stringorig = Properties.Resources.Orig_Terrain_Kola_radio,
+                //   stringsource = Properties.Resources.Append_Terrain_Kola_radio,
+                //   version ="2.8",
+                //   canremove = true,
+                //   reset = false,
+                //   //ACTIVE:
+                //   install = true,
+                //   export = false,
+                //   autoremove  = true,
+                //   quiet  = false,
+                //   AIRIO = true,
+                //   kneeboard = false,
+                // } },
                 };
 
             }

--- a/VAICOM/FileManager/LuaFiles_Install.cs
+++ b/VAICOM/FileManager/LuaFiles_Install.cs
@@ -533,7 +533,7 @@ namespace VAICOM
 
                                     if (!forcequiet)
                                     {
-                                        Log.Write("   " + updatecounter + "/10 DCS-side files were updated.", Colors.Text);
+                                        Log.Write("   " + updatecounter + "/9 DCS-side files were updated.", Colors.Text);
                                     }
 
                                     // Done, now install theme for this DCS version:


### PR DESCRIPTION
A bug was raised that Vaicom was replacing the Kola terrain `radio.lua` file with incorrect frequencies, and was also then replacing some of them with empty frequencies when VoiceAttack was exited.

DCS now appears to ship with a `radio.lua` file for Kola that contains all the ATCs and frequencies, so the replacement of this file is no longer necessary. This PR stops the replacement from occurring. Note, the actual replacement files and code for this has been left, just commented out where appropriate, to leave as a placeholder for future terrains that need this. 

Fixes #173 

Original DCS `radio.lua` file, this is not modified when starting up or shutting down Vaicom.

<img width="1195" height="427" alt="Screenshot 2026-02-02 143110" src="https://github.com/user-attachments/assets/eb99d552-b5aa-45af-a977-4259a1f4497f" />

Bodo ATC is correct as per the original bug report.

<img width="1175" height="129" alt="Screenshot 2026-02-02 143125" src="https://github.com/user-attachments/assets/f2ad3fd6-11c5-4443-8c19-98d736df32c5" />

Modified file count has now been reduced from 10 to 9 as there are now only 2 radio files modified, v.s. the original 3 prior to this change.

<img width="331" height="191" alt="Screenshot 2026-02-02 143051" src="https://github.com/user-attachments/assets/b11655fe-4db4-4678-b962-405866051e9a" />

**Known Issues**

- Due to Vaicom currently replacing the Kola `radio.lua` file when shutting down with one that is incorrect, users will be required to repair the game to have the contents of this restored back to its original state. This has not been introduced by the changes in this PR.
- Radio file replacement only takes place when the AIRIO extension is enabled, this is an existing bug.
 
