### PR TITLE
Use white text for the text in the debug window when in dark mode

### DIFF
--- a/VAICOM/ConfigWindow.xaml
+++ b/VAICOM/ConfigWindow.xaml
@@ -707,10 +707,10 @@
                 <TabItem x:Name="debugpage" Header="*" FontSize="13" Initialized="InitDebugTab">
                     <Grid Background="{DynamicResource UiWindowBackgroundBrush}" >
                         <Button x:Name="SendButton" Content="" HorizontalAlignment="Left" Margin="437,211,0,0" VerticalAlignment="Top" Width="26" FontSize="9" Cursor="Hand" Height="26" Click="SendDebugCode" ToolTip="Reset the selected items." BorderBrush="White" Background="#FF333333" Panel.ZIndex="255" Initialized="InitDebugBtn"/>
-                        <TextBox x:Name="CodeBlock" TextWrapping="Wrap" AcceptsReturn="True" HorizontalAlignment="Left" Height="246" Margin="10,10,0,0" Text="TextBox" VerticalAlignment="Top" Width="414" Initialized="InitCodeBlock"/>
+                        <TextBox x:Name="CodeBlock" TextWrapping="Wrap" AcceptsReturn="True" HorizontalAlignment="Left" Height="246" Margin="10,10,0,0" Text="TextBox" VerticalAlignment="Top" Width="414" Foreground="{DynamicResource UiWindowForegroundBrush}" Initialized="InitCodeBlock"/>
                         <Image x:Name="DumpCurrentState" HorizontalAlignment="Left" Height="20" Margin="440,100,0,0" VerticalAlignment="Top" Width="20" Source="Resources/Images/SRS_Dn.png" MouseDown="DumpState" Cursor="Hand" ToolTip="Dump Current State to Log" Panel.ZIndex="2"/>
-                        <TextBlock x:Name="labeldumpstate" FontSize="11" Foreground="#FFEEEEEE" HorizontalAlignment="Left" Margin="431,83,0,0" TextWrapping="Wrap" Text="STATE" VerticalAlignment="Top" Width="38" TextAlignment="Center" Height="16" FontWeight="Bold" Panel.ZIndex="1" />
-                        <TextBlock x:Name="labelsendchunk" FontSize="11" Foreground="#FFEEEEEE" HorizontalAlignment="Left" Margin="431,193,0,0" TextWrapping="Wrap" Text="SEND" VerticalAlignment="Top" Width="38" TextAlignment="Center" Height="16" FontWeight="Bold" Panel.ZIndex="1" />
+                        <TextBlock x:Name="labeldumpstate" FontSize="11" Foreground="{DynamicResource UiWindowForegroundBrush}" HorizontalAlignment="Left" Margin="431,83,0,0" TextWrapping="Wrap" Text="STATE" VerticalAlignment="Top" Width="38" TextAlignment="Center" Height="16" FontWeight="Bold" Panel.ZIndex="1" />
+                        <TextBlock x:Name="labelsendchunk" FontSize="11" Foreground="{DynamicResource UiWindowForegroundBrush}" HorizontalAlignment="Left" Margin="431,193,0,0" TextWrapping="Wrap" Text="SEND" VerticalAlignment="Top" Width="38" TextAlignment="Center" Height="16" FontWeight="Bold" Panel.ZIndex="1" />
                     </Grid>
                 </TabItem>
 


### PR DESCRIPTION
The text in the debug window was quite hard to see when in dark mode. In addition to this in light mode the labels for the dump state and send buttons were no longer visible.

Before:

<img width="1039" height="718" alt="Screenshot 2026-04-04 171127" src="https://github.com/user-attachments/assets/f4e85967-dcd9-4fab-8a45-1d3035c53b37" />

<img width="1045" height="703" alt="Screenshot 2026-04-04 171100" src="https://github.com/user-attachments/assets/e0398e6e-2ef1-4fb9-8f99-5316d5d82532" />

After:

<img width="1050" height="713" alt="Screenshot 2026-04-04 164504" src="https://github.com/user-attachments/assets/8b2a2469-e6d5-4dd7-98c4-846b7c05c021" />

<img width="1032" height="708" alt="Screenshot 2026-04-04 163429" src="https://github.com/user-attachments/assets/569ecd39-6233-41af-a238-af8607033c12" />
