### PR TITLE
Handle UDP update message sending errors breaking processing

### DIFF
--- a/VAICOM/Resources/Files/Append.Core.RadioCommandDialogsPanel.lua
+++ b/VAICOM/Resources/Files/Append.Core.RadioCommandDialogsPanel.lua
@@ -1597,7 +1597,6 @@ base.vaicom.state = {
 		rawcommand 				= base.vaicom.flags.raw,
 		menuaux					= {}, 
 		menucargo				= {},
-		menumoose				= {}, -- Add Moose
 		activemessage			= {},
 		availableradios			= {},
 		messagesent				= false,
@@ -1677,7 +1676,6 @@ base.vaicom.state = {
 					base.vaicom.state.availabilitycounter[recipientclass] = base.vaicom.helper.tablelength(base.vaicom.state.availablerecipients[recipientclass])
 				end
 				base.vaicom.state.menuaux							= data.initialized and data.menuOther
-				base.vaicom.state.menumoose							= data.initialized and data.menuOther -- Add Moose is this required?
 				base.vaicom.state.menucargo							= data.initialized and data.menuEmbarkToTransport
 				base.vaicom.state.dcsversion						= data.initialized and base.vaicom.get.serverdata.dcsversion()
 				base.vaicom.state.easycomms							= data.initialized and data.radioAutoTune
@@ -1767,7 +1765,6 @@ base.vaicom.state = {
 								  }								  
 				chunk[9] 		= {
 									menuaux		= (base.vaicom.state.activemessage.importmenus and base.vaicom.state.menuaux) 	or nil,
-									menumoose	= (base.vaicom.state.activemessage.importmenus and base.vaicom.state.menumoose) or nil, -- Add Moose
 									menucargo	= (base.vaicom.state.activemessage.importmenus and base.vaicom.state.menucargo) or nil,		
 								  }						
 				chunk[10] 		= {
@@ -1838,9 +1835,19 @@ base.vaicom.state = {
 					sndtbl.client 			= "VAICOMPRO"
 					sndtbl.mode 			= "normal"
 					sndtbl.type 			= "missiondata.update"
-					socket.try(base.vaicom.sender:send(JSON:encode(sndtbl)))
-				end	
-			end,								
+					-- Attempt to send message and log error instead of throwing error and
+					-- preventing rest of data being sent. These should succeed, however there
+					-- can be cases where large F10 menus can exceed the allowable packet size.
+					local ok, err = base.pcall(function()
+          				socket.try(base.vaicom.sender:send(JSON:encode(sndtbl)))
+					end)
+					if not ok then
+						for _, value in base.pairs(err) do
+							base.env.error("VAICOM error sending chunk "..i..", error: "..base.tostring(value))
+						end
+					end
+				end
+			end,
 }
 base.vaicom.devicecontrol = {
 	queue = {},


### PR DESCRIPTION
There have been issues with the sending of the update messages that have been linked to large F10 menus. It is suspected that this is due to the size of this data exceeding the maximum allowed for UDP packets, max is 65507 bytes. This causes the server processing to break, and the module not to be detected. Turning off the import of F10 menus is a workaround.

Changes in this PR use pcall to make the call, and then log errors when sending UDP messages but don't prevent the rest of the data chunks being sent.

Additional change to remove `moosemenu` as well. This is currently unused, but was a copy of the F10 menu so was contributing to the size of the chunk 9 aux menus payload.

Tested by hacking in a function which would generate payload sizes of 1Mb to exceed the limit. Verified that the aux menus chunk (chunk 9) was not sent and that the rest of the chunks weren't sent to the error being thrown. Verified that after this change the error is logged but all other chunks are sent, and everything works as expected.

Logging:

<img width="1392" height="41" alt="Screenshot 2026-04-06 184952" src="https://github.com/user-attachments/assets/eba44285-1171-41eb-b48b-7f0d6f993a2a" />

Vaicom logs that F10 data not received, nothing has changed here:

<img width="1049" height="43" alt="Screenshot 2026-04-06 184912" src="https://github.com/user-attachments/assets/66aabf4d-660e-4359-8fdc-29a81468d1c5" />