### PR TITLE
Send large auxmenu in parts as these can error due to packet size

### DIFF
--- a/VAICOM/Resources/Files/Append.Core.RadioCommandDialogsPanel.lua
+++ b/VAICOM/Resources/Files/Append.Core.RadioCommandDialogsPanel.lua
@@ -1765,7 +1765,7 @@ base.vaicom.state = {
 								  }								  
 				chunk[9] 		= {
 									menuaux		= (base.vaicom.state.activemessage.importmenus and base.vaicom.state.menuaux) 	or nil,
-									menucargo	= (base.vaicom.state.activemessage.importmenus and base.vaicom.state.menucargo) or nil,		
+									menucargo	= (base.vaicom.state.activemessage.importmenus and base.vaicom.state.menucargo) or nil,
 								  }						
 				chunk[10] 		= {
 									riostate = base.vaicom.state.riostate or nil,
@@ -1829,22 +1829,49 @@ base.vaicom.state = {
 								
 					end
 				end
-				for i= 1,11 do
-					local sndtbl = chunk[i]
-					sndtbl.cid 				= i									
-					sndtbl.client 			= "VAICOMPRO"
-					sndtbl.mode 			= "normal"
-					sndtbl.type 			= "missiondata.update"
-					-- Attempt to send message and log error instead of throwing error and
-					-- preventing rest of data being sent. These should succeed, however there
-					-- can be cases where large F10 menus can exceed the allowable packet size.
+				local function sendChunk(tbl, label)
 					local ok, err = base.pcall(function()
-          				socket.try(base.vaicom.sender:send(JSON:encode(sndtbl)))
+						socket.try(base.vaicom.sender:send(JSON:encode(tbl)))
 					end)
 					if not ok then
-						for _, value in base.pairs(err) do
-							base.env.error("VAICOM error sending chunk "..i..", error: "..base.tostring(value))
+						base.env.error("VAICOM error sending "..label..", error: "..base.tostring(err))
+					end
+					return ok
+				end
+				local function addChunkHeader(tbl, cid)
+					tbl.cid    = cid
+					tbl.client = "VAICOMPRO"
+					tbl.mode   = "normal"
+					tbl.type   = "missiondata.update"
+					return tbl
+				end
+				for chunkNum = 1, 11 do
+					if chunkNum == 9 then
+						-- Send chunk 9 (aux menus) separately, splitting into multiple
+						-- packets if the payload exceeds the maximum UDP packet size.
+						local encoded = JSON:encode(chunk[chunkNum])
+						local maxSize = 60000
+						if #encoded <= maxSize then
+							chunk[chunkNum].parts = 1
+							chunk[chunkNum].part  = 1
+							sendChunk(addChunkHeader(chunk[chunkNum], chunkNum), "chunk "..chunkNum)
+						else
+							local totalParts = base.math.ceil(#encoded / maxSize)
+							for partNum = 1, totalParts do
+								local startPos = (partNum - 1) * maxSize + 1
+								local segment = base.string.sub(encoded, startPos, startPos + maxSize - 1)
+								local partMsg = addChunkHeader({
+									parts		= totalParts,
+									part		= partNum,
+									segment		= segment,
+								}, chunkNum)
+								if not sendChunk(partMsg, "chunk "..chunkNum.." part "..partNum.."/"..totalParts) then
+									break
+								end
+							end
 						end
+					else
+						sendChunk(addChunkHeader(chunk[chunkNum], chunkNum), "chunk "..chunkNum)
 					end
 				end
 			end,

--- a/VAICOM/Resources/Files/Append.Core.RadioCommandDialogsPanel.lua
+++ b/VAICOM/Resources/Files/Append.Core.RadioCommandDialogsPanel.lua
@@ -1597,7 +1597,6 @@ base.vaicom.state = {
 		rawcommand 				= base.vaicom.flags.raw,
 		menuaux					= {}, 
 		menucargo				= {},
-		menumoose				= {}, -- Add Moose
 		activemessage			= {},
 		availableradios			= {},
 		messagesent				= false,
@@ -1677,7 +1676,6 @@ base.vaicom.state = {
 					base.vaicom.state.availabilitycounter[recipientclass] = base.vaicom.helper.tablelength(base.vaicom.state.availablerecipients[recipientclass])
 				end
 				base.vaicom.state.menuaux							= data.initialized and data.menuOther
-				base.vaicom.state.menumoose							= data.initialized and data.menuOther -- Add Moose is this required?
 				base.vaicom.state.menucargo							= data.initialized and data.menuEmbarkToTransport
 				base.vaicom.state.dcsversion						= data.initialized and base.vaicom.get.serverdata.dcsversion()
 				base.vaicom.state.easycomms							= data.initialized and data.radioAutoTune
@@ -1767,7 +1765,6 @@ base.vaicom.state = {
 								  }								  
 				chunk[9] 		= {
 									menuaux		= (base.vaicom.state.activemessage.importmenus and base.vaicom.state.menuaux) 	or nil,
-									menumoose	= (base.vaicom.state.activemessage.importmenus and base.vaicom.state.menumoose) or nil, -- Add Moose
 									menucargo	= (base.vaicom.state.activemessage.importmenus and base.vaicom.state.menucargo) or nil,		
 								  }						
 				chunk[10] 		= {
@@ -1838,9 +1835,19 @@ base.vaicom.state = {
 					sndtbl.client 			= "VAICOMPRO"
 					sndtbl.mode 			= "normal"
 					sndtbl.type 			= "missiondata.update"
-					socket.try(base.vaicom.sender:send(JSON:encode(sndtbl)))
-				end	
-			end,								
+					-- Attempt to send message and log error instead of throwing error and
+					-- preventing rest of data being sent. These should succeed, however there
+					-- can be cases where large F10 menus can exceed the allowable packet size.
+					local ok, err = base.pcall(function()
+          				socket.try(base.vaicom.sender:send(JSON:encode(sndtbl)))
+					end)
+					if not ok then
+						for _, value in base.pairs(err) do
+							base.env.error("VAICOM error sending chunk "..i..", error: "..base.tostring(value))
+						end
+					end
+				end
+			end,
 }
 base.vaicom.devicecontrol = {
 	queue = {},

--- a/VAICOM/Server/MessageTypes.cs
+++ b/VAICOM/Server/MessageTypes.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace VAICOM
@@ -389,6 +389,9 @@ namespace VAICOM
                 public ServerAuxmenu menuaux;
                 public ServerAuxmenu menucargo;
 
+                public int parts;
+                public int part;
+                public string segment;
 
             }
 

--- a/VAICOM/Server/ServerStateUpdate.cs
+++ b/VAICOM/Server/ServerStateUpdate.cs
@@ -287,20 +287,67 @@ namespace VAICOM
                 }
                 receivedupdatecomplete = false;
             }
+
+            private static int totalParts = 0;
+            private static int receivedParts = 0;
+            private static string[] chunkSegments = null;
+
             public static void ExtractChunk9(ServerMessage serverMessage)
             {
                 processingchunks = true;
                 try
                 {
-                    if (serverMessage.menuaux != null)
+                    if (serverMessage.parts <= 1)
                     {
-                        State.currentstate.menuaux = serverMessage.menuaux;
-                        State.currentstate.menucargo = serverMessage.menucargo;
+                        // Single part chunk
+                        if (serverMessage.menuaux != null)
+                        {
+                            State.currentstate.menuaux = serverMessage.menuaux;
+                            State.currentstate.menucargo = serverMessage.menucargo;
+                        }
+                    }
+                    else
+                    {
+                        // Multi-part: segments may arrive out of order via UDP.
+                        // Use an array indexed by part number to store each segment
+                        // and reassemble in correct order once all parts have arrived.
+                        if (serverMessage.parts != totalParts)
+                        {
+                            totalParts = serverMessage.parts;
+                            receivedParts = 0;
+                            chunkSegments = new string[totalParts];
+                        }
+
+                        int index = serverMessage.part - 1;
+                        if (index >= 0 && index < totalParts)
+                        {
+                            chunkSegments[index] = serverMessage.segment;
+                            receivedParts++;
+                        }
+
+                        // Check if all segments have been received
+                        if (receivedParts == totalParts)
+                        {
+                            // Reassemble segments in order and deserialize
+                            var assembled = string.Concat(chunkSegments);
+                            var chunk = JsonConvert.DeserializeObject<ServerMessage>(assembled);
+                            if (chunk?.menuaux != null)
+                            {
+                                State.currentstate.menuaux = chunk.menuaux;
+                                State.currentstate.menucargo = chunk.menucargo;
+                            }
+                            chunkSegments = null;
+                            totalParts = 0;
+                            receivedParts = 0;
+                        }
                     }
                 }
                 catch (Exception e)
                 {
                     Log.Write("ERROR 9/" + chunkcount + " :" + e.StackTrace, Colors.Inline);
+                    chunkSegments = null;
+                    totalParts = 0;
+                    receivedParts = 0;
                 }
                 receivedupdatecomplete = false;
             }


### PR DESCRIPTION
There have been issues with the sending of the update messages that have been linked to large F10 menus. It is suspected that this is due to the size of this data exceeding the maximum allowed for UDP packets, max is 65507 bytes. This causes the server processing to break, and the module not to be detected. Turning off the import of F10 menus is a workaround.

The fixes and improvements here will mean that larger menus can still be processed. In the advent that this fails, or other failures during sending, the rest of the server updates should still be processed as this won't throw an error. The module will still be detected and radios will continue to function.

Changes in this PR consist of the following:
- Use pcall to make the call, and then log errors when sending UDP messages but don't prevent the rest of the data chunks being sent
- If chunk 9 (the auxmenu) is greater than the max packet size (with a little wiggle room) then send it in individual parts. The number of parts to be sent, and the current part number, is sent in the message. On the server-side if the message is coming in parts then it waits till all parts have been received before then reassembling this back into a single aux menus payload.
- The `moosemenu` was also being sent as part of chunk 9. This was a copy of the auxmenus, but was not used server-side. This also causes the chunk size to blow out, so have deleted it.

UDP error handling was tested with the using of parts by hacking in a function which would generate payload sizes of 1Mb to exceed the limit. Verified that the aux menus chunk (chunk 9) was not sent and that the rest of the chunks weren't sent to the error being thrown. Verified that after this change the error is logged but all other chunks are sent, and everything works as expected.

Tested the handling of parts by reducing the maximum packet size to 250 and then verifying that I received multiple parts, they were all received, and the menu then created and imported into the database.

Part 1:

<img width="2573" height="310" alt="Screenshot 2026-04-08 201737" src="https://github.com/user-attachments/assets/f3c7841e-8937-4456-a431-a200ed6dbe7c" />

Part 2:

<img width="2554" height="207" alt="Screenshot 2026-04-08 201753" src="https://github.com/user-attachments/assets/d3df287b-f505-4f78-b53b-c596beb3bc2c" />

Part 3 and then importing into the database:

<img width="1506" height="1345" alt="Screenshot 2026-04-08 201836" src="https://github.com/user-attachments/assets/60b1cc5c-e1e1-4aa2-aeb8-b7cdfc8b5688" />


DCS logging for failing to send chunk messages over UDP:

<img width="1392" height="41" alt="Screenshot 2026-04-06 184952" src="https://github.com/user-attachments/assets/111618e6-2e26-4486-bd36-0614f77b91de" />

Vaicom/VoiceAttack logging on failure to receive F10 menu:


<img width="1049" height="43" alt="Screenshot 2026-04-06 184912" src="https://github.com/user-attachments/assets/21056d01-47ac-4546-bc10-89d43395fa67" />
