### PR TITLE
Ignore menus larger than the allowed maximum chunk size

### DIFF
--- a/VAICOM/Resources/Files/Append.Core.RadioCommandDialogsPanel.lua
+++ b/VAICOM/Resources/Files/Append.Core.RadioCommandDialogsPanel.lua
@@ -1829,14 +1829,15 @@ base.vaicom.state = {
 								
 					end
 				end
-				local function sendChunk(tbl, label)
+				local function sendChunk(payload, chunkId)
 					local ok, err = base.pcall(function()
-						socket.try(base.vaicom.sender:send(JSON:encode(tbl)))
+						socket.try(base.vaicom.sender:send(payload))
 					end)
 					if not ok then
-						base.env.error("VAICOM error sending "..label..", error: "..base.tostring(err))
+						for _, value in base.pairs(err) do
+							base.env.error("VAICOM error sending chunk "..chunkId..", error: "..base.tostring(value))
+						end
 					end
-					return ok
 				end
 				local function addChunkHeader(tbl, cid)
 					tbl.cid    = cid
@@ -1845,33 +1846,20 @@ base.vaicom.state = {
 					tbl.type   = "missiondata.update"
 					return tbl
 				end
-				for chunkNum = 1, 11 do
-					if chunkNum == 9 then
-						-- Send chunk 9 (aux menus) separately, splitting into multiple
-						-- packets if the payload exceeds the maximum UDP packet size.
-						local encoded = JSON:encode(chunk[chunkNum])
-						local maxSize = 60000
-						if #encoded <= maxSize then
-							chunk[chunkNum].parts = 1
-							chunk[chunkNum].part  = 1
-							sendChunk(addChunkHeader(chunk[chunkNum], chunkNum), "chunk "..chunkNum)
-						else
-							local totalParts = base.math.ceil(#encoded / maxSize)
-							for partNum = 1, totalParts do
-								local startPos = (partNum - 1) * maxSize + 1
-								local segment = base.string.sub(encoded, startPos, startPos + maxSize - 1)
-								local partMsg = addChunkHeader({
-									parts		= totalParts,
-									part		= partNum,
-									segment		= segment,
-								}, chunkNum)
-								if not sendChunk(partMsg, "chunk "..chunkNum.." part "..partNum.."/"..totalParts) then
-									break
-								end
-							end
+				-- Maximum udp packet size for localhost
+				-- (64K - 20 IP header - 8 UDP header)
+				local maxSize = (64 * 1024) - 20 - 8
+				for chunkId = 1, 11 do
+					local chunkPayload = addChunkHeader(chunk[chunkId], chunkId)
+					local payload = JSON:encode(chunkPayload)
+					if chunkId == 9 then
+						-- Large menus that exceed the maximum payload cause errors
+						-- during sending and prevent sending all chunks to VAICOM.
+						if #payload < maxSize then
+							sendChunk(payload, chunkId)
 						end
 					else
-						sendChunk(addChunkHeader(chunk[chunkNum], chunkNum), "chunk "..chunkNum)
+						sendChunk(payload, chunkId)
 					end
 				end
 			end,

--- a/VAICOM/Server/ServerStateUpdate.cs
+++ b/VAICOM/Server/ServerStateUpdate.cs
@@ -287,67 +287,20 @@ namespace VAICOM
                 }
                 receivedupdatecomplete = false;
             }
-
-            private static int totalParts = 0;
-            private static int receivedParts = 0;
-            private static string[] chunkSegments = null;
-
             public static void ExtractChunk9(ServerMessage serverMessage)
             {
                 processingchunks = true;
                 try
                 {
-                    if (serverMessage.parts <= 1)
+                    if (serverMessage.menuaux != null)
                     {
-                        // Single part chunk
-                        if (serverMessage.menuaux != null)
-                        {
-                            State.currentstate.menuaux = serverMessage.menuaux;
-                            State.currentstate.menucargo = serverMessage.menucargo;
-                        }
-                    }
-                    else
-                    {
-                        // Multi-part: segments may arrive out of order via UDP.
-                        // Use an array indexed by part number to store each segment
-                        // and reassemble in correct order once all parts have arrived.
-                        if (serverMessage.parts != totalParts)
-                        {
-                            totalParts = serverMessage.parts;
-                            receivedParts = 0;
-                            chunkSegments = new string[totalParts];
-                        }
-
-                        int index = serverMessage.part - 1;
-                        if (index >= 0 && index < totalParts)
-                        {
-                            chunkSegments[index] = serverMessage.segment;
-                            receivedParts++;
-                        }
-
-                        // Check if all segments have been received
-                        if (receivedParts == totalParts)
-                        {
-                            // Reassemble segments in order and deserialize
-                            var assembled = string.Concat(chunkSegments);
-                            var chunk = JsonConvert.DeserializeObject<ServerMessage>(assembled);
-                            if (chunk?.menuaux != null)
-                            {
-                                State.currentstate.menuaux = chunk.menuaux;
-                                State.currentstate.menucargo = chunk.menucargo;
-                            }
-                            chunkSegments = null;
-                            totalParts = 0;
-                            receivedParts = 0;
-                        }
+                        State.currentstate.menuaux = serverMessage.menuaux;
+                        State.currentstate.menucargo = serverMessage.menucargo;
                     }
                 }
                 catch (Exception e)
                 {
                     Log.Write("ERROR 9/" + chunkcount + " :" + e.StackTrace, Colors.Inline);
-                    chunkSegments = null;
-                    totalParts = 0;
-                    receivedParts = 0;
                 }
                 receivedupdatecomplete = false;
             }
@@ -405,4 +358,3 @@ namespace VAICOM
         }
     }
 }
-


### PR DESCRIPTION
Some F10 menus can be extremely large and exceed the maximum size allowed for UDP packets to be sent to the VAICOM server.

A previous change attempted to send these in parts and reconstruct them on the server but had additional issues. Given the nature of some of these menus, and what they contain, storing all the items in the VAICOM database and VoiceAttack keywords can be redundant. To reduce complexities and issues its simpler to ignore larger menus that will exceed these limits.